### PR TITLE
Fix search, due to missing Cherish Ball.

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
                 <option value="friend-ball">Friend Ball</option>
                 <option value="moon-ball">Moon Ball</option>
                 <option value="sport-ball">Sport Ball</option>
+                <option value="cherish-ball">Cherish Ball</option>
                 <option value="dream-ball">Dream Ball</option>
                 <option value="beast-ball">Beast Ball</option>
             </select>


### PR DESCRIPTION
Because the Cherish Ball is missing, all Pokémon caught in a Cherish Ball will be removed/filtered/left out from a search.